### PR TITLE
some important changes

### DIFF
--- a/GLFileView.m
+++ b/GLFileView.m
@@ -409,7 +409,12 @@
 +(BOOL)isDiffHeader:(NSString*)line
 {
 	unichar c=[line characterAtIndex:0];
-	return (c=='i') || (c=='m') || (c=='n') || (c=='d') || (c=='-') || (c=='+'); 
+	return
+		(c=='s') || // git mv: similarity index 100%
+		(c=='r') || // git mv: rename (from|to) ...
+		(c=='o') || // chmod: old mode ...
+		(c=='n') || // chmod: new mode ...
+		(c=='i') || (c=='m') || (c=='n') || (c=='d') || (c=='-') || (c=='+');
 }
 
 +(BOOL)isImage:(NSString*)file

--- a/PBGitCommitController.m
+++ b/PBGitCommitController.m
@@ -172,7 +172,6 @@
 	[commitMessageView setEditable:YES];
 	[commitMessageView setString:@""];
 	[webController setStateMessage:[NSString stringWithFormat:[[notification userInfo] objectForKey:@"description"]]];
-	[repository reloadRefs];
 }	
 
 - (void)commitFailed:(NSNotification *)notification


### PR DESCRIPTION
hello.

i made some patches for review:
1) refresh commit history after commit
2) retain commit position in commit history after refreshing history (when selected latest commit, cursor changes to latest commit in refreshed history). ticket #281
3) when origin has mirror flag, push failed because command include refspec for commit (git push origin master) but this is unacceptable for git. in this case command must be (git push origin)
4) due to bug in parser, sometimes commit not displayed properly (at least when diff contains no changes in code, only permissions change)

my code not best, but it allow me to work with gitx without most annoying bugs.

thank you very much for maintaining good software!
