### PR TITLE
Error on repo open fix

### DIFF
--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -118,6 +118,7 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 //this works much better.
 - (BOOL)readFromURL:(NSURL *)absoluteURL ofType:(NSString *)typeName error:(NSError **)outError
 {
+	@try {
 	if (![PBGitBinary path])
 	{
 		if (outError) {
@@ -153,6 +154,14 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 	[self setFileURL:gitDirURL];
 	[self setup];
 	return YES;
+	} @catch(id x) {
+		if (outError) {
+			NSDictionary* userInfo = [NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"An error occured while trying to open %@.\n%@", [self fileURL],x]
+																 forKey:NSLocalizedRecoverySuggestionErrorKey];
+			*outError = [NSError errorWithDomain:PBGitRepositoryErrorDomain code:0 userInfo:userInfo];
+		}
+		return NO;
+	}
 }
 
 - (void) setup

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -280,6 +280,11 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 	else
 		sha = [PBGitSHA shaWithString:[components objectAtIndex:2]];
 
+	if(!sha) {
+		NSLog(@"sha was nil...? ref=%@, components=%@",ref,components);
+		return;
+	}
+
 	NSMutableArray* curRefs;
 	if ( (curRefs = [refs objectForKey:sha]) != nil )
 		[curRefs addObject:ref];
@@ -298,6 +303,13 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 	NSArray *arguments = [NSArray arrayWithObjects:@"for-each-ref", @"--format=%(refname) %(objecttype) %(objectname) %(*objectname)", @"refs", nil];
 	NSString *output = [self outputForArguments:arguments];
 	NSArray *lines = [output componentsSeparatedByString:@"\n"];
+
+	if([output hasPrefix:@"fatal: "]) {
+		NSLog(@"Unable to read refs!");
+		NSLog(@"arguments=%@",arguments);
+		NSLog(@"output=%@",output);
+		@throw output;
+	}
 
 	for (NSString *line in lines) {
 		// If its an empty line, skip it (e.g. with empty repositories)


### PR DESCRIPTION
I noticed that sometimes for-each-ref can fail entirely if a ref contains a pointer to another ref which no longer exists. In this case gitx simply does nothing---no error, no explanation. This change makes GitX properly report an error under such circumstances.
