### PR TITLE
Enable multiline git config values.

### DIFF
--- a/PBGitConfig.m
+++ b/PBGitConfig.m
@@ -99,19 +99,20 @@
     NSArray* arguments;
     
     if (inDir == nil) {
-        arguments = [NSArray arrayWithObjects:@"config", @"--global", @"-l", nil];
+        arguments = [NSArray arrayWithObjects:@"config", @"--global", @"-l", @"-z", nil];
     } else {
-        arguments = [NSArray arrayWithObjects:@"config", @"-l", nil];
+        arguments = [NSArray arrayWithObjects:@"config", @"-l", @"-z", nil];
     }
     
 	int ret = 1;
 	NSString* output = [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir:inDir retValue:&ret];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     if (ret==0) {
-        NSArray *lines = [output componentsSeparatedByString:@"\n"];
-        
+        NSArray *lines = [output componentsSeparatedByString:@"\0"];
+
         for (NSString* line in lines) {
-            NSRange equalsPos = [line rangeOfString:@"="];
+			if([line length] == 0) continue;
+            NSRange equalsPos = [line rangeOfString:@"\n"];
             NSString* key = [line substringToIndex:equalsPos.location];
             NSString* value = [line substringFromIndex:equalsPos.location+1];
             [result setObject:value forKey:key];


### PR DESCRIPTION
Use `git config -l -z` to get configs. The key/values are null terminated. The keys are separated from the values by a newline. This allows multiline config values without crashing. Here's an example of a multiline config:

```
[merge "railsschema"]
  name = newer Rails schema version
  driver = "ruby -e '\n\
    system %(git), %(merge-file), %(--marker-size=%L), %(%A), %(%O), %(%B)\n\
    b = File.read(%(%A))\n\
    b.sub!(/^<+ .*\\nActiveRecord::Schema\\.define.:version => (\\d+). do\\n=+\\nActiveRecord::Schema\\.define.:version => (\\d+). do\\n>+ .*/) do\n\
      %(ActiveRecord::Schema.define(:version => #{[$1, $2].max}) do)\n\
    end\n\
    File.open(%(%A), %(w)) {|f| f.write(b)}\n\
    exit 1 if b.include?(%(<)*%L)'"
```
