### PR TITLE
Quote app path

### DIFF
--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -1337,7 +1337,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Build the scripting bridge header GitX.h if the GitX.sdef file changes\nsdef $TARGET_BUILD_DIR/GitX.app | sdp -fh --basename GitX";
+			shellScript = "# Build the scripting bridge header GitX.h if the GitX.sdef file changes\nsdef \"$TARGET_BUILD_DIR/GitX.app\" | sdp -fh --basename GitX";
 		};
 		F56439F60F792B2100A579C2 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This is the change I had to do in order to build the project in my projects folder. My home directory is server based and thus has a space in the path (since the remote server's disk volume name is `Macintosh HD`). Quoting the path in this build phase allows the project to build successfully.
