### PR TITLE
Help tags for remotes and tags

### DIFF
--- a/PBGitRepository.h
+++ b/PBGitRepository.h
@@ -127,6 +127,7 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 - (BOOL) hasRemotes;
 - (PBGitRef *) remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error;
 - (NSString *) infoForRemote:(NSString *)remoteName;
+- (NSArray*) URLsForRemote:(NSString*)remoteName;
 
 - (void) readCurrentBranch;
 - (PBGitRevSpecifier*) addBranch: (PBGitRevSpecifier*) rev;

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -326,6 +326,7 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 		PBGitRef *newRef = [PBGitRef refFromString:[components objectAtIndex:0]];
 		PBGitRevSpecifier *revSpec = [[PBGitRevSpecifier alloc] initWithRef:newRef];
 
+		[revSpec setHelpText:[self helpTextForRef:newRef]];
 		[self addBranch:revSpec];
 		[self addRef:newRef fromParameters:components];
 		[oldBranches removeObject:revSpec];

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -278,6 +278,32 @@ NSString* PBGitRepositoryErrorDomain = @"GitXErrorDomain";
 		[refs setObject:[NSMutableArray arrayWithObject:ref] forKey:sha];
 }
 
+// Extracts the text that should be shown in a help tag
+- (NSString*) helpTextForRef:(PBGitRef*)ref
+{
+	NSString *output = nil;
+	NSString *name = [ref shortName];
+	NSArray *arguments = nil;
+
+	if ([ref isRemote]) {
+		arguments = [NSArray arrayWithObjects:@"remote", @"show", @"-n", name, nil];
+		output = [self outputForArguments:arguments];
+
+		NSArray *remoteLines = [output componentsSeparatedByString:@"\n"];
+
+		// Second and third lines have Fetch and Push URLs
+		return [[remoteLines subarrayWithRange:NSMakeRange(1,1)] componentsJoinedByString:@"\n"];
+	}
+	else if ([ref isTag]) {
+		arguments = [NSArray arrayWithObjects:@"tag", @"-ln", name, nil];
+		output = [self outputForArguments:arguments];
+		if (![output hasPrefix:name])
+			return nil;
+		return [[output substringFromIndex:[name length]] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+	}
+	return nil;
+}
+
 - (void) reloadRefs
 {
 	_headRef = nil;

--- a/PBGitRevSpecifier.h
+++ b/PBGitRevSpecifier.h
@@ -11,6 +11,7 @@
 
 @interface PBGitRevSpecifier : NSObject  <NSCopying> {
 	NSString *description;
+	NSString *helpText;
 	NSArray *parameters;
 	NSURL *workingDirectory;
 	BOOL isSimpleRef;
@@ -36,6 +37,7 @@
 + (PBGitRevSpecifier *)localBranchesRevSpec;
 
 @property(retain)   NSString *description;
+@property(retain)   NSString *helpText;
 @property(readonly) NSArray *parameters;
 @property(retain)   NSURL *workingDirectory;
 @property(readonly) BOOL isSimpleRef;

--- a/PBGitRevSpecifier.m
+++ b/PBGitRevSpecifier.m
@@ -11,7 +11,7 @@
 
 @implementation PBGitRevSpecifier
 
-@synthesize parameters, description, workingDirectory;
+@synthesize parameters, description, helpText, workingDirectory;
 @synthesize isSimpleRef;
 @synthesize behind,ahead;
 

--- a/PBGitSVRemoteItem.h
+++ b/PBGitSVRemoteItem.h
@@ -12,9 +12,11 @@
 
 @interface PBGitSVRemoteItem : PBSourceViewItem {
 	BOOL alert;
+	NSString *helpText;
 }
 
 @property (assign) BOOL alert;
+@property (retain) NSString *helpText;
 
 + (id)remoteItemWithTitle:(NSString *)title;
 

--- a/PBGitSVRemoteItem.m
+++ b/PBGitSVRemoteItem.m
@@ -13,6 +13,7 @@
 @implementation PBGitSVRemoteItem
 
 @synthesize alert;
+@synthesize helpText;
 
 + (id)remoteItemWithTitle:(NSString *)title
 {

--- a/PBGitSidebarController.h
+++ b/PBGitSidebarController.h
@@ -20,9 +20,9 @@
 	IBOutlet NSPopUpButton *actionButton;
 	IBOutlet NSSegmentedControl *remoteControls;
 
-    IBOutlet NSButton* svnFetchButton;
-    IBOutlet NSButton* svnRebaseButton;
-    IBOutlet NSButton* svnDcommitButton;
+	IBOutlet NSButton* svnFetchButton;
+	IBOutlet NSButton* svnRebaseButton;
+	IBOutlet NSButton* svnDcommitButton;
     
 	NSMutableArray *items;
 

--- a/PBGitSidebarController.m
+++ b/PBGitSidebarController.m
@@ -344,7 +344,7 @@ static NSString * const kObservingContextSubmodules = @"submodulesChanged";
 
 - (NSString *)outlineView:(NSOutlineView *)outlineView toolTipForCell:(NSCell *)cell rect:(NSRectPointer)rect tableColumn:(NSTableColumn *)tc item:(id)item mouseLocation:(NSPoint)mouseLocation
 {
-	return [item helpText];
+	return [[item revSpecifier] helpText];
 }
 
 - (BOOL)outlineView:(NSOutlineView *)outlineView shouldSelectItem:(id)item

--- a/PBGitSidebarController.m
+++ b/PBGitSidebarController.m
@@ -342,6 +342,11 @@ static NSString * const kObservingContextSubmodules = @"submodulesChanged";
 	[cell setImage:[item icon]];
 }
 
+- (NSString *)outlineView:(NSOutlineView *)outlineView toolTipForCell:(NSCell *)cell rect:(NSRectPointer)rect tableColumn:(NSTableColumn *)tc item:(id)item mouseLocation:(NSPoint)mouseLocation
+{
+	return [item helpText];
+}
+
 - (BOOL)outlineView:(NSOutlineView *)outlineView shouldSelectItem:(id)item
 {
 	return ![item isGroupItem];

--- a/PBGitSidebarController.m
+++ b/PBGitSidebarController.m
@@ -344,7 +344,7 @@ static NSString * const kObservingContextSubmodules = @"submodulesChanged";
 
 - (NSString *)outlineView:(NSOutlineView *)outlineView toolTipForCell:(NSCell *)cell rect:(NSRectPointer)rect tableColumn:(NSTableColumn *)tc item:(id)item mouseLocation:(NSPoint)mouseLocation
 {
-	return [[item revSpecifier] helpText];
+	return [item helpText];
 }
 
 - (BOOL)outlineView:(NSOutlineView *)outlineView shouldSelectItem:(id)item
@@ -363,6 +363,17 @@ static NSString * const kObservingContextSubmodules = @"submodulesChanged";
 - (BOOL) outlineView:(NSOutlineView *)outlineView shouldShowOutlineCellForItem:(id)item
 {
 	return ![item isUncollapsible];
+}
+
+- (NSString*) helpTextForRemoteURLs:(NSArray*)urls
+{
+	NSString *fetchURL = [urls objectAtIndex:0];
+	NSString *pushURL = [urls objectAtIndex:1];
+
+	if ([fetchURL isEqual:pushURL])
+		return fetchURL;
+	else	// Down triangle for fetch, up triangle for push
+		return [NSString stringWithFormat:@"\u25bc %@\n\u25b2", fetchURL, pushURL];
 }
 
 - (void)populateList
@@ -384,6 +395,8 @@ static NSString * const kObservingContextSubmodules = @"submodulesChanged";
 	
 	for (PBGitRevSpecifier *rev in repository.branches)
 		[self addRevSpec:rev];
+	for (PBGitSVRemoteItem *remote in remotes.children)
+		[remote setHelpText:[self helpTextForRemoteURLs:[[self repository] URLsForRemote:[remote title]]]];
 	
 	[items addObject:project];
 	[items addObject:branches];

--- a/PBSourceViewItem.h
+++ b/PBSourceViewItem.h
@@ -14,7 +14,7 @@
 @interface PBSourceViewItem : NSObject {
 	NSMutableArray *children;
 
-	NSString *title, *helpText;
+	NSString *title;
 	PBGitRevSpecifier *revSpecifier;
 	PBSourceViewItem *parent;
 
@@ -43,7 +43,6 @@
 - (PBGitRef *) ref;
 
 @property(retain) NSString *title;
-@property(retain) NSString *helpText;
 @property(readonly) NSMutableArray *children;
 @property(assign) BOOL isGroupItem, isUncollapsible;
 @property(retain) PBGitRevSpecifier *revSpecifier;

--- a/PBSourceViewItem.h
+++ b/PBSourceViewItem.h
@@ -14,7 +14,7 @@
 @interface PBSourceViewItem : NSObject {
 	NSMutableArray *children;
 
-	NSString *title;
+	NSString *title, *helpText;
 	PBGitRevSpecifier *revSpecifier;
 	PBSourceViewItem *parent;
 
@@ -43,6 +43,7 @@
 - (PBGitRef *) ref;
 
 @property(retain) NSString *title;
+@property(retain) NSString *helpText;
 @property(readonly) NSMutableArray *children;
 @property(assign) BOOL isGroupItem, isUncollapsible;
 @property(retain) PBGitRevSpecifier *revSpecifier;

--- a/PBSourceViewItem.h
+++ b/PBSourceViewItem.h
@@ -30,6 +30,7 @@
 + (id)itemWithTitle:(NSString *)title;
 
 - (NSString *)badge;
+- (NSString *)helpText;
 
 - (void)addChild:(PBSourceViewItem *)child;
 - (void)removeChild:(PBSourceViewItem *)child;

--- a/PBSourceViewItem.m
+++ b/PBSourceViewItem.m
@@ -128,6 +128,11 @@
 	return [[revSpecifier description] lastPathComponent];
 }
 
+- (NSString *) helpText
+{
+	return [revSpecifier helpText];
+}
+
 - (NSString *) stringValue
 {
 	return self.title;


### PR DESCRIPTION
This displays help tags for remotes and tags in the sidebar. For remotes, it shows the fetch/pull URLs, and for tags it shows the description.
