### PR TITLE
GitX doesn't quite honor diff.renames

### DIFF
--- a/PBWebHistoryController.m
+++ b/PBWebHistoryController.m
@@ -104,11 +104,11 @@
 	NSMutableDictionary *stats = [self parseStats:details];
 
 	// File list
-	NSString *dt = [repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"diff-tree", @"--root", @"-r", @"-C90%", @"-M90%", currentSha, nil]];
+	NSString *dt = [repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"diff-tree", @"--root", @"-r", @"-C", @"-M", currentSha, nil]];
 	NSString *fileList = [GLFileView parseDiffTree:dt withStats:stats];
 	
 	// Diffs list
-	NSString *d = [repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"diff-tree", @"--root", @"--cc", @"-C90%", @"-M90%", currentSha, nil]];
+	NSString *d = [repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"diff-tree", @"--root", @"--cc", @"-C", @"-M", currentSha, nil]];
 	NSString *diffs = [GLFileView parseDiff:d];
 	
 	NSString *html = [NSString stringWithFormat:@"%@%@<div id='diffs'>%@</div>",header,fileList,diffs];


### PR DESCRIPTION
I have recently walked into a use case where it made my life _so much easier_ to have my diffs track renames in order for me to actually see the content change, rather than having it buried in the <delete,add> pair.

Hence I have <tt>git config --global diff.renames true</tt> in order to get basic renames detection in the "git show" and alike, which does the job just great.

However, it appears that GitX is still showing a full blown <delete,add> diff, so I would suppose the git command thrown in the background to read the diff prevents git from doing rename detection... It would be nice if that could be fixed (so it conforms to the standard git behavior).
