### PR TITLE
Replace 10.7 API with 10.6 API

### DIFF
--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -1618,7 +1618,6 @@
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = GitX;
-				SDKROOT = "";
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = YES;
 			};
@@ -1646,7 +1645,6 @@
 				INSTALL_PATH = "$(HOME)/Applications";
 				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = GitX;
-				SDKROOT = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1665,7 +1663,7 @@
 				INFOPLIST_PREPROCESS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx10.6;
 			};
 			name = Debug;
 		};
@@ -1682,7 +1680,7 @@
 				INFOPLIST_PREPROCESS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx10.6;
 			};
 			name = Release;
 		};

--- a/PBWebController.m
+++ b/PBWebController.m
@@ -37,9 +37,9 @@
 	[view setResourceLoadDelegate:self];
 
 	NSURL *resourceURL = [[[NSBundle mainBundle] resourceURL] URLByStandardizingPath];
-	NSURL *baseURL = [[resourceURL URLByAppendingPathComponent:@"html/views" isDirectory:YES] URLByAppendingPathComponent:startFile isDirectory:YES];
+	NSURL *baseURL = [[resourceURL URLByAppendingPathComponent:@"html/views"] URLByAppendingPathComponent:startFile];
 	
-	NSURL *fileURL = [baseURL URLByAppendingPathComponent:@"index.html" isDirectory:NO];
+	NSURL *fileURL = [baseURL URLByAppendingPathComponent:@"index.html"];
 	[[view mainFrame] loadRequest:[NSURLRequest requestWithURL:fileURL]];
 }
 


### PR DESCRIPTION
A recent change - 59701cbe73b82b2772b1550f16274d96e3b52893 - introduced the usage of URLByAppendingPathComponent:isDirectory: which requires 10.7. I changed it to URLByAppendingPathComponent: which requires 10.6, and changed the project to build for 10.6 instead of 10.5.
