### PR TITLE
GitX Crash with "other" remotes

### DIFF
--- a/PBGitSVOtherRevItem.h
+++ b/PBGitSVOtherRevItem.h
@@ -14,6 +14,8 @@
 
 }
 
+@property(retain) NSString* helpText;
+
 + (id)otherItemWithRevSpec:(PBGitRevSpecifier *)revSpecifier;
 
 @end

--- a/PBGitSVOtherRevItem.m
+++ b/PBGitSVOtherRevItem.m
@@ -12,6 +12,8 @@
 
 @implementation PBGitSVOtherRevItem
 
+@synthesize helpText=_helpText;
+
 
 + (id)otherItemWithRevSpec:(PBGitRevSpecifier *)revSpecifier
 {


### PR DESCRIPTION
Hi,

I fixed a bug where GitX would crash with old git-svn remotes. The reason is that the code iterates over all PBGitSVRemoteItem in PBGitSidebarController::populateList, but those entries are not PBGitSVRemoteItem but rather PBGitSVOtherRevItem. I added the helpText property to PBGitSVOtherRevItem to fix this.

Cheers,
Martin

-- Commit Message ---
- Fixed bug where GitX would crash if there exists old remotes that originally belonged to old git-svn remotes.
- Added helpText property to PBGitSVOtherRevItem
