### PR TITLE
Improvements to commit view

### DIFF
--- a/PBWebCommitController.h
+++ b/PBWebCommitController.h
@@ -19,11 +19,13 @@
 	
 	NSString* currentSha;
 	NSString* diff;
+	BOOL showLongDiffs;
 }
 
 - (void) changeContentTo: (PBGitCommit *) content;
 - (void) sendKey: (NSString*) key;
 - (void) openFileMerge:(NSString*)file sha:(NSString *)sha sha2:(NSString *)sha2;
+- (void) showLongDiff;
 
 - (void) didLoad;
 // Called when a commit or parent link is clicked.

--- a/PBWebCommitController.m
+++ b/PBWebCommitController.m
@@ -232,6 +232,7 @@ const NSString *kAuthorKeyDate = @"date";
 	NSMutableString *auths=[NSMutableString string];
 	NSMutableString *refs=[NSMutableString string];
 	NSMutableString *subject=[NSMutableString string];
+	NSMutableString *all=[NSMutableString string];
 	
 	for (NSDictionary *item in header) {
 		if ([[item objectForKey:kHeaderKeyName] isEqualToString:@"subject"]) {
@@ -269,7 +270,17 @@ const NSString *kAuthorKeyDate = @"date";
 		}
 	}	
 	
-	return [NSString stringWithFormat:@"<div id='header' class='clearfix'><table class='references'>%@</table><p class='subject'>%@</p>%@<div id='badges'>%@</div></div><p>%@</p>",refs,subjectFirst,auths,badges,subject];
+	[all appendString:[NSString stringWithFormat:@"<div id='header' class='clearfix'><table class='references'>%@</table><p class='subject'>%@</p>%@",refs,subjectFirst,auths]];
+
+	if (![badges isEqualToString:@""])
+		[all appendString:[NSString stringWithFormat:@"<div id='badges'>%@</div>",badges]];
+
+	[all appendString:@"</div>"];
+
+	if (![subject isEqualToString:@""])
+		[all appendString:[NSString stringWithFormat:@"<p>%@</p>",subject]];
+
+	return all;
 }
 
 - (NSString *) arbitraryHashForString:(NSString*)concat {

--- a/PBWebCommitController.m
+++ b/PBWebCommitController.m
@@ -32,8 +32,14 @@ const NSString *kAuthorKeyDate = @"date";
 
 @synthesize diff;
 
+- (void) showLongDiff
+{
+	showLongDiffs = TRUE;
+}
+
 - (void) awakeFromNib
 {
+	showLongDiffs = FALSE;
 	startFile = @"history";
 	[super awakeFromNib];
 }
@@ -118,10 +124,16 @@ const NSString *kAuthorKeyDate = @"date";
 	[args addObjectsFromArray:parents];
 	[args addObject:currentSha];
 	NSString *d = [repository outputInWorkdirForArguments:args];
-	NSString *diffs = [GLFileView parseDiff:d];
-	
-	NSString *html = [NSString stringWithFormat:@"%@%@<div id='diffs'>%@</div>",header,fileList,diffs];
-	
+	NSString *html;
+	if(showLongDiffs || [d length] < 200000)
+	{
+		showLongDiffs = FALSE;
+		NSString *diffs = [GLFileView parseDiff:d];
+		html = [NSString stringWithFormat:@"%@%@<div id='diffs'>%@</div>",header,fileList,diffs];
+	} else {
+		html = [NSString stringWithFormat:@"%@%@<div id='diffs'><p>This is a very large commit. It may take a long time to load the diff. Click <a href='' onclick='showFullDiff(); return false;'>here</a> to show anyway.</p></div>",header,fileList,currentSha];
+	}
+
 	html = [html stringByReplacingOccurrencesOfString:@"{SHA_PREV}" withString:[NSString stringWithFormat:@"%@^",currentSha]];
 	html = [html stringByReplacingOccurrencesOfString:@"{SHA}" withString:currentSha];
 	

--- a/PBWebCommitController.m
+++ b/PBWebCommitController.m
@@ -278,7 +278,7 @@ const NSString *kAuthorKeyDate = @"date";
 	[all appendString:@"</div>"];
 
 	if (![subject isEqualToString:@""])
-		[all appendString:[NSString stringWithFormat:@"<p>%@</p>",subject]];
+		[all appendString:[NSString stringWithFormat:@"<p class='subjectDetail'>%@</p>",subject]];
 
 	return all;
 }

--- a/PBWebCommitController.m
+++ b/PBWebCommitController.m
@@ -228,13 +228,19 @@ const NSString *kAuthorKeyDate = @"date";
 - (NSString *)htmlForHeader:(NSArray *)header withRefs:(NSString *)badges
 {
 	NSString *last_mail = @"";
+	NSMutableString *subjectFirst = [NSMutableString string];
 	NSMutableString *auths=[NSMutableString string];
 	NSMutableString *refs=[NSMutableString string];
 	NSMutableString *subject=[NSMutableString string];
 	
 	for (NSDictionary *item in header) {
 		if ([[item objectForKey:kHeaderKeyName] isEqualToString:@"subject"]) {
-			[subject appendString:[NSString stringWithFormat:@"%@<br/>",[GLFileView escapeHTML:[item objectForKey:kHeaderKeyContent]]]];
+			if ([subjectFirst isEqualToString:@""]) {
+				[subjectFirst appendString:[NSString stringWithFormat:@"%@",[GLFileView escapeHTML:[item objectForKey:kHeaderKeyContent]]]];
+			} else {
+				[subject appendString:[NSString stringWithFormat:@"%@<br/>",[GLFileView escapeHTML:[item objectForKey:kHeaderKeyContent]]]];
+			}
+
 		}else{
 			if([[item objectForKey:kHeaderKeyContent] isKindOfClass:[NSString class]]){
 				[refs appendString:[NSString stringWithFormat:@"<tr><td>%@</td><td><a href='' onclick='selectCommit(this.innerHTML); return false;'>%@</a></td></tr>",[item objectForKey:kHeaderKeyName],[item objectForKey:kHeaderKeyContent]]];
@@ -263,7 +269,7 @@ const NSString *kAuthorKeyDate = @"date";
 		}
 	}	
 	
-	return [NSString stringWithFormat:@"<div id='header' class='clearfix'><table class='references'>%@</table><p class='subject'>%@</p>%@<div id='badges'>%@</div></div>",refs,subject,auths,badges];
+	return [NSString stringWithFormat:@"<div id='header' class='clearfix'><table class='references'>%@</table><p class='subject'>%@</p>%@<div id='badges'>%@</div></div><p>%@</p>",refs,subjectFirst,auths,badges,subject];
 }
 
 - (NSString *) arbitraryHashForString:(NSString*)concat {

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -202,6 +202,7 @@ a.showdiff {
 
 #filelist tr td {
 	border-bottom: 1px solid #ccc;
+	border-top: 1px solid #ccc;
 }
 
 #filelist a {
@@ -312,7 +313,6 @@ a.showdiff {
 }
 
 #diffs {
-	-webkit-box-shadow: inset 0px 5px 5px #ccc;
 	width: 100%;
 	display: block;
 	padding-top: 10px;

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -104,6 +104,10 @@ a.servicebutton {
 	float: none;
 }
 
+p.subjectDetail {
+    padding: 5px;
+}
+
 #files {
 	margin-top: 1em;
 	margin-left: 0.5em;

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -102,6 +102,7 @@ a.servicebutton {
 	font-size: 13px;
 	padding: 5px;
 	float: none;
+	font-weight: bold;
 }
 
 p.subjectDetail {

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -21,3 +21,7 @@ var showCommit = function(data){
 	$("commit").innerHTML=data;
 }
 
+var showFullDiff = function() {
+    Controller.showLongDiff();
+    Controller.updateView();
+}


### PR DESCRIPTION
These changes improve the appearance of the commit view in a couple of ways:
- Diffs for very large commits are not shown by default. In some repositories I work with, there are very large diffs which cause gitx to hang for several seconds.
- Commit messages are separated into summary (first line) and details sections. Only the summary is shown in the header, the rest is shown below.
- Minor cosmetic tweaks.
