### PR TITLE
fix to handle bad stash output

### DIFF
--- a/Model/PBGitStash.m
+++ b/Model/PBGitStash.m
@@ -19,7 +19,7 @@
 	if ((self = [super init])) {
 		stashRawString = [stashLineFromStashListOutput retain];
 		NSArray *lineComponents = [stashLineFromStashListOutput componentsSeparatedByString:@":"];
-		if (lineComponents != 3) {
+		if ([lineComponents count] != 3) {
 			[self release];
 			return nil;
 		}

--- a/Model/PBGitStash.m
+++ b/Model/PBGitStash.m
@@ -19,6 +19,10 @@
 	if ((self = [super init])) {
 		stashRawString = [stashLineFromStashListOutput retain];
 		NSArray *lineComponents = [stashLineFromStashListOutput componentsSeparatedByString:@":"];
+		if (lineComponents != 3) {
+			[self release];
+			return nil;
+		}
 		name = [[lineComponents objectAtIndex:0] retain];
 		stashSourceMessage = [[[lineComponents objectAtIndex:1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] retain];
 		message = [[[lineComponents objectAtIndex:2] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] retain];

--- a/PBStashController.m
+++ b/PBStashController.m
@@ -46,7 +46,8 @@ static NSString * const kCommandName = @"stash";
 		if ([stashLine length] == 0)
 			continue;
 		PBGitStash *stash = [[PBGitStash alloc] initWithRawStashLine:stashLine];
-		[loadedStashes addObject:stash];
+		if (stash != nil)
+			[loadedStashes addObject:stash];
 		[stash release];
 	}
 	


### PR DESCRIPTION
My repository somehow got into a state where "git stash list" includes an extra line with just ":", causing an uncaught exception in gitx. This fix adds nil checking so bad entries are skipped.
