### PR TITLE
Allow building in Snow Leopard

### DIFF
--- a/PBGitWindowController.m
+++ b/PBGitWindowController.m
@@ -16,6 +16,11 @@
 #import "PBGitXMessageSheet.h"
 #import "PBGitSidebarController.h"
 
+#ifndef MAC_OS_X_VERSION_10_7
+#define NSApplicationPresentationAutoHideToolbar 0
+#define NSApplicationPresentationFullScreen 0
+#endif
+
 @implementation PBGitWindowController
 
 


### PR DESCRIPTION
`NSApplicationPresentationAutoHideToolbar` and `NSApplicationPresentationFullScreen` are Lion only.
Defining them with 0 value will allow the class to compile under Snow Leopard.
I would define them with their actual value in Lion but:
1. I’m in front of a Snow Leopard machine right now, and
2. While it would build, I’m not sure about the results when running under Snow Leopard and providing those values as options.
