### PR TITLE
Speedups for reloading refs when there are lots of tags.

### DIFF
--- a/PBGitRepository.h
+++ b/PBGitRepository.h
@@ -42,6 +42,8 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 @class PBStashController;
 @class PBSubmoduleController;
 
+dispatch_queue_t PBGetWorkQueue();
+
 @interface PBGitRepository : NSDocument {
 	PBGitHistoryList* revisionList;
 	PBGitConfig *config;
@@ -58,6 +60,10 @@ static NSString * PBStringFromBranchFilterType(PBGitXBranchFilterType type) {
 	PBStashController *stashController;
 	PBSubmoduleController *submoduleController;
 	PBGitResetController *resetController;
+
+	BOOL didCheckBareRepository;
+	BOOL bareRepository;
+	NSString* workingDirectory;
 }
 @property (nonatomic, retain, readonly) PBStashController *stashController;
 @property (nonatomic, retain, readonly) PBSubmoduleController *submoduleController;


### PR DESCRIPTION
This change uses GCD to schedule certain git commands for
background execution. All background commands occur on the
queue returned by PBGetWorkQueue(), and the results are
executed on the main queue. This results in a dramatic
improvement in the performance of reloadRefs when there
are lots of tags.

More improvements are possible with this approach, this is
just something to get things rolling.
