### PR TITLE
prevents open dialog from appearing when opening a repo from the cli

### DIFF
--- a/ApplicationController.m
+++ b/ApplicationController.m
@@ -129,11 +129,6 @@
 
 	if (![[NSApplication sharedApplication] isActive])
 		return;
-
-	// The current directory was not enabled or could not be opened (most likely it’s not a git repository).
-	// show an open panel for the user to select a repository to view
-	if ([PBGitDefaults showOpenPanelOnLaunch] && !hasOpenedDocuments && cloneRepositoryPanel == nil)
-		[[PBRepositoryDocumentController sharedDocumentController] openDocument:self];
 }
 
 - (void)getUrl:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
@@ -403,6 +398,19 @@
 	}
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
+{
+    id dc = [PBRepositoryDocumentController sharedDocumentController];
+    
+    // Reopen last document if user prefers
+    if ([PBGitDefaults showOpenPanelOnLaunch])
+    {
+        [dc openDocument:self];
+    }
+    
+    return NO;
 }
 
 /**


### PR DESCRIPTION
On Lion an Open dialog appears when GitX is opened from the cli as `hasOpenedDocuments` no longer seems to account for when the application is invoked with a repo URL. This bug affects all Lion users who have "Show Open panel on launch" enabled (which is the default).

To solve this, I moved the open dialog logic out of `applicationDidFinishLaunching` and into `applicationShouldOpenUntitledFile`. This has been tested on OS X Lion, but I have not been able to test on previous versions yet.

This fixes #152 and #151 and possibly others.
