### PR TITLE
Asynchronously update submodules and load commit diffs

### DIFF
--- a/Controller/PBSubmoduleController.m
+++ b/Controller/PBSubmoduleController.m
@@ -21,36 +21,37 @@
 
 
 - (void) reload {
-	NSArray *arguments = [NSArray arrayWithObjects:@"submodule", @"status", @"--recursive", nil];
-	NSString *output = [repository outputInWorkdirForArguments:arguments];
-	NSArray *lines = [output componentsSeparatedByString:@"\n"];
-	
-	NSMutableArray *loadedSubmodules = [[NSMutableArray alloc] initWithCapacity:[lines count]];
-	
-	for (NSString *submoduleLine in lines) {
-		if ([submoduleLine length] == 0)
-			continue;
-		PBGitSubmodule *submodule = [[PBGitSubmodule alloc] initWithRawSubmoduleStatusString:submoduleLine];
-		if (submodule)
-			[loadedSubmodules addObject:submodule];
-	}
-	
-	NSMutableArray *groupedSubmodules = [[NSMutableArray alloc] init];
-	for (PBGitSubmodule *submodule in loadedSubmodules) {
-		BOOL added = NO;
-		for (PBGitSubmodule *addedItem in groupedSubmodules) {
-			if ([[submodule path] hasPrefix:[addedItem path]]) {
-				[addedItem addSubmodule:submodule];
-				added = YES;
-			}
-		}
-		if (!added) {
-			[groupedSubmodules addObject:submodule];
-		}
-	}
-	
-	
-	submodules = loadedSubmodules;
+    dispatch_async(PBGetWorkQueue(), ^{
+        NSArray *arguments = [NSArray arrayWithObjects:@"submodule", @"status", @"--recursive", nil];
+        NSString *output = [repository outputInWorkdirForArguments:arguments];
+        NSArray *lines = [output componentsSeparatedByString:@"\n"];
+        
+        NSMutableArray *loadedSubmodules = [[NSMutableArray alloc] initWithCapacity:[lines count]];
+        
+        for (NSString *submoduleLine in lines) {
+            if ([submoduleLine length] == 0)
+                continue;
+            PBGitSubmodule *submodule = [[PBGitSubmodule alloc] initWithRawSubmoduleStatusString:submoduleLine];
+            if (submodule)
+                [loadedSubmodules addObject:submodule];
+        }
+        
+        NSMutableArray *groupedSubmodules = [[NSMutableArray alloc] init];
+        for (PBGitSubmodule *submodule in loadedSubmodules) {
+            BOOL added = NO;
+            for (PBGitSubmodule *addedItem in groupedSubmodules) {
+                if ([[submodule path] hasPrefix:[addedItem path]]) {
+                    [addedItem addSubmodule:submodule];
+                    added = YES;
+                }
+            }
+            if (!added) {
+                [groupedSubmodules addObject:submodule];
+            }
+        }
+        
+        submodules = loadedSubmodules;
+    });
 }
 
 #pragma mark -

--- a/English.lproj/PBChangeRemoteUrlSheet.xib
+++ b/English.lproj/PBChangeRemoteUrlSheet.xib
@@ -43,7 +43,7 @@
 			<object class="NSWindowTemplate" id="1005">
 				<int key="NSWindowStyleMask">15</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{63, 1353}, {764, 148}}</string>
+				<string key="NSWindowRect">{{63, 500}, {764, 148}}</string>
 				<int key="NSWTFlags">544735232</int>
 				<string key="NSWindowTitle">Change Remote URL</string>
 				<string key="NSWindowClass">NSWindow</string>

--- a/English.lproj/PBCloneRepositoryPanel.xib
+++ b/English.lproj/PBCloneRepositoryPanel.xib
@@ -43,7 +43,7 @@
 			<object class="NSWindowTemplate" id="1005">
 				<int key="NSWindowStyleMask">15</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{63, 1353}, {488, 185}}</string>
+				<string key="NSWindowRect">{{63, 500}, {488, 185}}</string>
 				<int key="NSWTFlags">544735232</int>
 				<string key="NSWindowTitle">Clone Git Repository</string>
 				<string key="NSWindowClass">NSWindow</string>


### PR DESCRIPTION
Asynchronously update submodules when refreshing. The main thread lags for a second or two on projects with lots of submodules otherwise.
Load commit diffs asynchronously as well, which reduces UI stutter when scrolling through a lot of commits quickly.
Also cleaned up a couple nib warnings.
