### PR TITLE
Fix for submodules display & graphing memory leak

### DIFF
--- a/Controller/PBSubmoduleController.m
+++ b/Controller/PBSubmoduleController.m
@@ -10,7 +10,13 @@
 #import "PBGitRepository.h"
 #import "PBOpenDocumentCommand.h"
 
+@interface PBSubmoduleController()
+@property (nonatomic, retain) NSArray *submodules;
+@end
+
+
 @implementation PBSubmoduleController
+@synthesize submodules;
 
 - (id) initWithRepository:(PBGitRepository *) repo {
     if ((self = [super init])){
@@ -50,7 +56,7 @@
             }
         }
         
-        submodules = loadedSubmodules;
+        self.submodules = loadedSubmodules;
     });
 }
 
@@ -114,7 +120,7 @@
 		shouldBeEnabled = NO;
 		//TODO implementation missing
 	} else {
-		shouldBeEnabled = [submodules count] > 0;
+		shouldBeEnabled = [self.submodules count] > 0;
 	}
 	return shouldBeEnabled;
 }

--- a/Controller/PBSubmoduleController.m
+++ b/Controller/PBSubmoduleController.m
@@ -10,13 +10,7 @@
 #import "PBGitRepository.h"
 #import "PBOpenDocumentCommand.h"
 
-@interface PBSubmoduleController()
-@property (nonatomic, retain) NSArray *submodules;
-@end
-
-
 @implementation PBSubmoduleController
-@synthesize submodules;
 
 - (id) initWithRepository:(PBGitRepository *) repo {
     if ((self = [super init])){
@@ -56,7 +50,7 @@
             }
         }
         
-        self.submodules = loadedSubmodules;
+        submodules = loadedSubmodules;
     });
 }
 
@@ -120,7 +114,7 @@
 		shouldBeEnabled = NO;
 		//TODO implementation missing
 	} else {
-		shouldBeEnabled = [self.submodules count] > 0;
+		shouldBeEnabled = [submodules count] > 0;
 	}
 	return shouldBeEnabled;
 }

--- a/PBGraphCellInfo.m
+++ b/PBGraphCellInfo.m
@@ -21,6 +21,11 @@
 	return self;
 }
 
+- (void)dealloc
+{
+	free(lines);
+}
+
 - (void)setLines:(struct PBGitGraphLine *)l
 {
 	free(lines);


### PR DESCRIPTION
2 minor fixes:
- it appears (at least on Lion) that git submodules are never showing up in the sidebar because the KVO notifications are never fired.  Changing PBSubmoduleController's modules ivar to a property fixes this.
- ARC does not automatically free malloc'ed memory.  This was creating a leak in PBGraphCellInfo because the lines ivar is never freed.  Added a -dealloc method (which is still called under ARC) to clean it up.
