### PR TITLE
Fixed lots of retain cycles which caused memory leaks

### DIFF
--- a/Controller/PBGitResetController.h
+++ b/Controller/PBGitResetController.h
@@ -13,7 +13,7 @@
 @protocol PBGitRefish;
 
 @interface PBGitResetController : NSObject {
-	PBGitRepository *repository;
+	__unsafe_unretained PBGitRepository *repository;
 }
 - (id) initWithRepository:(PBGitRepository *) repo;
 

--- a/Controller/PBSubmoduleController.h
+++ b/Controller/PBSubmoduleController.h
@@ -14,7 +14,7 @@
 
 @interface PBSubmoduleController : NSObject {
 @private
-	PBGitRepository *repository;
+	__unsafe_unretained PBGitRepository *repository;
     NSArray *submodules;
 }
 

--- a/Controller/PBSubmoduleController.m
+++ b/Controller/PBSubmoduleController.m
@@ -50,7 +50,11 @@
             }
         }
         
-        submodules = loadedSubmodules;
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self willChangeValueForKey:@"submodules"];
+			submodules = loadedSubmodules;
+			[self didChangeValueForKey:@"submodules"];
+		});
     });
 }
 

--- a/GLFileView.h
+++ b/GLFileView.h
@@ -18,8 +18,8 @@
 @class PBGitGradientBarView;
 
 @interface GLFileView : PBWebController <MGScopeBarDelegate> {
-	IBOutlet PBGitHistoryController* historyController;
-	IBOutlet MGScopeBar *typeBar;
+	__unsafe_unretained PBGitHistoryController* historyController;
+	__unsafe_unretained MGScopeBar *typeBar;
 	NSMutableArray *groups;
 	NSString *logFormat;
 	NSString *diffType;
@@ -28,6 +28,9 @@
     IBOutlet NSSearchField *searchField;
     PBGitTree *lastFile;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *historyController;
+@property(nonatomic, unsafe_unretained) IBOutlet MGScopeBar *typeBar;
 
 - (void)showFile;
 - (void)didLoad;

--- a/GLFileView.m
+++ b/GLFileView.m
@@ -30,6 +30,8 @@
 
 @implementation GLFileView
 
+@synthesize historyController, typeBar;
+
 - (void) awakeFromNib
 {
 	NSString *formatFile = [[NSBundle mainBundle] pathForResource:@"format" ofType:@"html" inDirectory:@"html/views/log"];

--- a/GitXTextFieldCell.h
+++ b/GitXTextFieldCell.h
@@ -11,7 +11,9 @@
 
 
 @interface GitXTextFieldCell : NSTextFieldCell {
-	IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
+	__unsafe_unretained id<PBRefContextDelegate> contextMenuDelegate;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
 
 @end

--- a/GitXTextFieldCell.m
+++ b/GitXTextFieldCell.m
@@ -13,6 +13,8 @@
 
 @implementation GitXTextFieldCell
 
+@synthesize contextMenuDelegate;
+
 - (NSColor *)highlightColorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
 	// disables the cell's selection highlight

--- a/MGScopeBar/MGScopeBar.h
+++ b/MGScopeBar/MGScopeBar.h
@@ -11,7 +11,7 @@
 
 @interface MGScopeBar : NSView {
 @private
-	IBOutlet id <MGScopeBarDelegate, NSObject> delegate; // weak ref.
+	__unsafe_unretained id <MGScopeBarDelegate, NSObject> delegate; // weak ref.
 	NSMutableArray *_separatorPositions; // x-coords of separators, indexed by their group-number.
 	NSMutableArray *_groups; // groups of items.
 	NSView *_accessoryView; // weak ref since it's a subview.
@@ -24,7 +24,7 @@
 	BOOL _smartResizeEnabled; // whether to do our clever collapsing/expanding of buttons when resizing (Smart Resizing).
 }
 
-@property(strong,nonatomic) id delegate; // should implement the MGScopeBarDelegate protocol.
+@property(unsafe_unretained,nonatomic) IBOutlet id delegate; // should implement the MGScopeBarDelegate protocol.
 
 - (void)reloadData; // causes the scope-bar to reload all groups/items from its delegate.
 - (void)sizeToFit; // only resizes vertically to optimum height; does not affect width.

--- a/PBCommitList.h
+++ b/PBCommitList.h
@@ -18,13 +18,17 @@
 // delegate: PBGitHistoryController
 @interface PBCommitList : NSTableView {
 	IBOutlet WebView* webView;
-	IBOutlet PBWebHistoryController *webController;
-	IBOutlet PBGitHistoryController *controller;
-	IBOutlet PBHistorySearchController *searchController;
+	__unsafe_unretained PBWebHistoryController *webController;
+	__unsafe_unretained PBGitHistoryController *controller;
+	__unsafe_unretained PBHistorySearchController *searchController;
 
     BOOL useAdjustScroll;
 	NSPoint mouseDownPoint;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBWebHistoryController *webController;
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *controller;
+@property(nonatomic, unsafe_unretained) IBOutlet PBHistorySearchController *searchController;
 
 @property (readonly) NSPoint mouseDownPoint;
 @property (assign) BOOL useAdjustScroll;

--- a/PBCommitList.m
+++ b/PBCommitList.m
@@ -13,6 +13,7 @@
 
 @implementation PBCommitList
 
+@synthesize webController, controller, searchController;
 @synthesize mouseDownPoint;
 @synthesize useAdjustScroll;
 

--- a/PBGitCommit.h
+++ b/PBGitCommit.h
@@ -29,7 +29,7 @@ extern NSString * const kGitXCommitType;
 	int timestamp;
 	char sign;
 	id lineInfo;
-	PBGitRepository* repository;
+	__unsafe_unretained PBGitRepository* repository;
 }
 
 + (PBGitCommit *)commitWithRepository:(PBGitRepository*)repo andSha:(NSString *)newSha;
@@ -65,6 +65,6 @@ extern NSString * const kGitXCommitType;
 @property (readonly) NSString* details;
 @property (readonly) PBGitTree* tree;
 @property (readonly) NSArray* treeContents;
-@property (strong) PBGitRepository* repository;
+@property (unsafe_unretained) PBGitRepository* repository;
 @property (strong) id lineInfo;
 @end

--- a/PBGitHistoryController.h
+++ b/PBGitHistoryController.h
@@ -23,18 +23,12 @@
 
 // Controls the split history view from PBGitHistoryView.xib
 @interface PBGitHistoryController : PBViewController PROTOCOL_10_6(NSOutlineViewDelegate){
-	IBOutlet PBRefController *refController;
 	IBOutlet NSSearchField *searchField;
-	IBOutlet NSArrayController*  commitController;
 	IBOutlet NSSearchField *filesSearchField;
-	IBOutlet NSTreeController*  treeController;
 	IBOutlet NSOutlineView* fileBrowser;
 	NSArray *currentFileBrowserSelectionPath;
-	IBOutlet PBCommitList*  commitList;
-	IBOutlet NSSplitView *historySplitView;
 	IBOutlet PBWebHistoryController *webHistoryController;
 	QLPreviewPanel* previewPanel;
-	IBOutlet PBHistorySearchController *searchController;
 	IBOutlet GLFileView *fileView;
 
 	IBOutlet PBGitGradientBarView *upperToolbarView;
@@ -57,15 +51,15 @@
 	PBGitCommit *selectedCommitBeforeRefresh;
 }
 
-@property (readonly) NSTreeController* treeController;
-@property (readonly) NSSplitView *historySplitView;
+@property (unsafe_unretained) IBOutlet NSTreeController* treeController;
+@property (unsafe_unretained) IBOutlet NSSplitView *historySplitView;
 @property (nonatomic,assign) int selectedCommitDetailsIndex;
 @property (strong) PBGitCommit *webCommit;
 @property (strong) PBGitTree* gitTree;
-@property (readonly) NSArrayController *commitController;
-@property (readonly) PBRefController *refController;
-@property (readonly) PBHistorySearchController *searchController;
-@property (readonly) PBCommitList *commitList;
+@property (unsafe_unretained) IBOutlet NSArrayController *commitController;
+@property (unsafe_unretained) IBOutlet PBRefController *refController;
+@property (unsafe_unretained) IBOutlet PBHistorySearchController *searchController;
+@property (unsafe_unretained) PBCommitList *commitList;
 
 - (IBAction) setDetailedView:(id)sender;
 - (IBAction) setTreeView:(id)sender;

--- a/PBGitHistoryController.m
+++ b/PBGitHistoryController.m
@@ -483,11 +483,12 @@
 {
 	[self saveSplitViewPosition];
 
-	if (commitController) {
-		[commitController removeObserver:self forKeyPath:@"selection"];
-		[commitController removeObserver:self forKeyPath:@"arrangedObjects.@count"];
-		[treeController removeObserver:self forKeyPath:@"selection"];
+	[commitController removeObserver:self forKeyPath:@"selection"];
+	[commitController removeObserver:self forKeyPath:@"arrangedObjects.@count"];
+	[treeController removeObserver:self forKeyPath:@"selection"];
 
+	//Only stop these observations if the nib got loaded
+	if ([self treeController]) {
 		[repository.revisionList removeObserver:self forKeyPath:@"isUpdating"];
 		[repository removeObserver:self forKeyPath:@"currentBranch"];
 		[repository removeObserver:self forKeyPath:@"refs"];

--- a/PBGitHistoryController.m
+++ b/PBGitHistoryController.m
@@ -488,7 +488,7 @@
 	[treeController removeObserver:self forKeyPath:@"selection"];
 
 	//Only stop these observations if the nib got loaded
-	if ([self treeController]) {
+	if (hasViewLoaded) {
 		[repository.revisionList removeObserver:self forKeyPath:@"isUpdating"];
 		[repository removeObserver:self forKeyPath:@"currentBranch"];
 		[repository removeObserver:self forKeyPath:@"refs"];

--- a/PBGitHistoryGrapher.h
+++ b/PBGitHistoryGrapher.h
@@ -17,7 +17,7 @@
 
 
 @interface PBGitHistoryGrapher : NSObject {
-	id delegate;
+	__unsafe_unretained id delegate;
 	NSOperationQueue *currentQueue;
 
 	NSMutableSet *searchSHAs;

--- a/PBGitHistoryList.h
+++ b/PBGitHistoryList.h
@@ -16,7 +16,7 @@
 @class PBGitHistoryGrapher;
 
 @interface PBGitHistoryList : NSObject {
-	PBGitRepository *repository;
+	__unsafe_unretained PBGitRepository *repository;
 
 	PBGitRevList *projectRevList;
 	PBGitRevList *currentRevList;

--- a/PBGitHistoryList.m
+++ b/PBGitHistoryList.m
@@ -85,10 +85,9 @@
 
 - (void)cleanup
 {
-	if (currentRevList) {
-		[currentRevList removeObserver:self forKeyPath:@"commits"];
-		[currentRevList cancel];
-	}
+	[currentRevList removeObserver:self forKeyPath:@"commits"];
+	[currentRevList cancel];
+	
 	[graphQueue cancelAllOperations];
 
 	[repository removeObserver:self forKeyPath:@"currentBranch"];

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -1965,9 +1965,4 @@ dispatch_queue_t PBGetWorkQueue() {
 	return nil;
 }
 
-- (void) finalize
-{
-	//DLog(@"Dealloc of repository");
-	[super finalize];
-}
 @end

--- a/PBGitRevList.h
+++ b/PBGitRevList.h
@@ -14,7 +14,7 @@
 @interface PBGitRevList : NSObject {
 	NSMutableArray *commits;
 
-	PBGitRepository *repository;
+	__unsafe_unretained PBGitRepository *repository;
 	PBGitRevSpecifier *currentRev;
 	BOOL isGraphing;
 

--- a/PBGitRevList.mm
+++ b/PBGitRevList.mm
@@ -238,6 +238,17 @@ using namespace std;
 
 	[task terminate];
 	[task waitUntilExit];
+	
+	//Nasty hack to work around ARC and bindings getting angry at each other
+	//Without this some of the view controllers can get released while not on the main thread, which crashes in bindings
+	__block PBGitRepository *tempRepository = repository;
+	
+	double delayInSeconds = 2.0;
+	dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+	dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+		if ([tempRepository isKindOfClass:[PBGitRepository class]]) {
+		}
+	});
 }
 
 @end

--- a/PBGitRevisionCell.h
+++ b/PBGitRevisionCell.h
@@ -16,9 +16,13 @@
 	PBGitCommit *objectValue;
 	PBGraphCellInfo *cellInfo;
 	NSTextFieldCell *textCell;
-	IBOutlet PBGitHistoryController *controller;
-	IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
+	__unsafe_unretained PBGitHistoryController *controller;
+	__unsafe_unretained id<PBRefContextDelegate> contextMenuDelegate;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *controller;
+@property(nonatomic, unsafe_unretained) IBOutlet id<PBRefContextDelegate> contextMenuDelegate;
+
 
 - (int) indexAtX:(float)x;
 - (NSRect) rectAtIndex:(int)index;

--- a/PBGitRevisionCell.m
+++ b/PBGitRevisionCell.m
@@ -13,6 +13,7 @@
 
 @implementation PBGitRevisionCell
 
+@synthesize controller, contextMenuDelegate;
 
 - (id) initWithCoder: (id) coder
 {

--- a/PBGitSidebarController.m
+++ b/PBGitSidebarController.m
@@ -91,6 +91,7 @@ NSString *kObservingContextSubmodules = @"submodulesChanged";
 	[commitViewController closeView];
 	[stashViewController closeView];
 	
+    [repository removeObserver:self forKeyPath:@"refs"];
 	[repository removeObserver:self forKeyPath:@"currentBranch"];
 	[repository removeObserver:self forKeyPath:@"branches"];
 	[repository removeObserver:self forKeyPath:@"stashController.stashes"];

--- a/PBHistorySearchController.h
+++ b/PBHistorySearchController.h
@@ -21,7 +21,7 @@ typedef enum historySearchModes {
 
 
 @interface PBHistorySearchController : NSObject {
-	PBGitHistoryController *historyController;
+	__unsafe_unretained PBGitHistoryController *historyController;
 	NSArrayController *commitController;
 
 	PBHistorySearchMode searchMode;
@@ -38,7 +38,7 @@ typedef enum historySearchModes {
 	NSPanel *rewindPanel;
 }
 
-@property (strong) IBOutlet PBGitHistoryController *historyController;
+@property (unsafe_unretained) IBOutlet PBGitHistoryController *historyController;
 @property (strong) IBOutlet NSArrayController *commitController;
 
 @property (strong) IBOutlet NSSearchField *searchField;

--- a/PBQLOutlineView.h
+++ b/PBQLOutlineView.h
@@ -10,7 +10,9 @@
 #import "PBGitHistoryController.h"
 
 @interface PBQLOutlineView : NSOutlineView {
-	IBOutlet PBGitHistoryController* controller;
+	__unsafe_unretained PBGitHistoryController *controller;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *controller;
 
 @end

--- a/PBQLOutlineView.m
+++ b/PBQLOutlineView.m
@@ -11,6 +11,8 @@
 
 @implementation PBQLOutlineView
 
+@synthesize controller;
+
 - initWithCoder: (NSCoder *) coder
 {
 	id a = [super initWithCoder:coder];

--- a/PBQLTextView.h
+++ b/PBQLTextView.h
@@ -13,7 +13,9 @@
 
 
 @interface PBQLTextView : NSTextView {
-	IBOutlet PBGitHistoryController *controller;
+	__unsafe_unretained PBGitHistoryController *controller;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *controller;
 
 @end

--- a/PBQLTextView.m
+++ b/PBQLTextView.m
@@ -12,6 +12,8 @@
 
 @implementation PBQLTextView
 
+@synthesize controller;
+
 - (void) keyDown: (NSEvent *) event
 {
 	if ([[event characters] isEqualToString:@" "]) {

--- a/PBRefController.h
+++ b/PBRefController.h
@@ -16,7 +16,7 @@
 @class PBRefMenuItem;
 
 @interface PBRefController : NSObject <PBRefContextDelegate> {
-	IBOutlet PBGitHistoryController *historyController;
+	__unsafe_unretained PBGitHistoryController *historyController;
 	IBOutlet NSArrayController *commitController;
 	IBOutlet PBCommitList *commitList;
 
@@ -24,6 +24,8 @@
     NSDictionary *actDropInfo;
     PBGitRef *actRef;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *historyController;
 
 - (void) fetchRemote:(PBRefMenuItem *)sender;
 - (void) pullRemote:(PBRefMenuItem *)sender;

--- a/PBRefController.m
+++ b/PBRefController.m
@@ -27,6 +27,8 @@
 
 @implementation PBRefController
 
+@synthesize historyController;
+
 -(void)dealloc
 {
     actDropInfo = Nil;

--- a/PBStashController.h
+++ b/PBStashController.h
@@ -13,7 +13,7 @@
 
 @interface PBStashController : NSObject {
 @private
-    PBGitRepository *repository;
+    __unsafe_unretained PBGitRepository *repository;
 }
 
 - (id) initWithRepository:(PBGitRepository *) repo;

--- a/PBViewController.h
+++ b/PBViewController.h
@@ -11,16 +11,16 @@
 #import "PBGitWindowController.h"
 
 @interface PBViewController : NSViewController {
-	PBGitRepository *repository;
-	PBGitWindowController *superController;
+	__unsafe_unretained PBGitRepository *repository;
+	__unsafe_unretained PBGitWindowController *superController;
 
 	NSString *status;
 	BOOL isBusy;
 	BOOL hasViewLoaded;
 }
 
-@property (readonly) PBGitRepository *repository;
-@property (readonly) PBGitWindowController *superController;
+@property (readonly, unsafe_unretained) PBGitRepository *repository;
+@property (readonly, unsafe_unretained) PBGitWindowController *superController;
 @property(copy) NSString *status;
 @property(assign) BOOL isBusy;
 

--- a/PBWebController.h
+++ b/PBWebController.h
@@ -20,11 +20,11 @@
 	NSMapTable *callbacks;
 
 	// For the repository access
-	IBOutlet PBGitRepository *repository;
+	IBOutlet __unsafe_unretained PBGitRepository *repository;
 }
 
 @property (strong) NSString *startFile;
-@property (strong) PBGitRepository *repository;
+@property (unsafe_unretained) PBGitRepository *repository;
 
 - (WebScriptObject *) script;
 - (void) closeView;

--- a/PBWebHistoryController.h
+++ b/PBWebHistoryController.h
@@ -12,7 +12,9 @@
 @class PBGitHistoryController;
 
 @interface PBWebHistoryController : PBWebCommitController {
-	IBOutlet PBGitHistoryController* historyController;
+	__unsafe_unretained PBGitHistoryController* historyController;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBGitHistoryController *historyController;
 
 @end

--- a/PBWebHistoryController.m
+++ b/PBWebHistoryController.m
@@ -12,6 +12,8 @@
 
 @implementation PBWebHistoryController
 
+@synthesize historyController;
+
 - (void) awakeFromNib
 {
 	startFile = @"history";

--- a/PBWebStashController.h
+++ b/PBWebStashController.h
@@ -10,7 +10,9 @@
 @class PBStashContentController;
 
 @interface PBWebStashController : PBWebCommitController {
-	IBOutlet PBStashContentController *stashController;
+	__unsafe_unretained PBStashContentController *stashController;
 }
+
+@property(nonatomic, unsafe_unretained) IBOutlet PBStashContentController *stashController;
 
 @end

--- a/PBWebStashController.m
+++ b/PBWebStashController.m
@@ -9,6 +9,8 @@
 
 @implementation PBWebStashController
 
+@synthesize stashController;
+
 - (void)selectCommit:(NSString *)sha
 {
 	[[stashController superController] selectCommitForSha:sha];


### PR DESCRIPTION
The switch to ARC made a ton of retain cycles which was causing PBGitRepository and all of the associated view controllers to leak every time a document was closed. This breaks all the cycles so they don't leak anymore.

There's also a nasty workaround to the view controllers getting released while not on the main thread. That should probably replaced if anyone has a better idea.
