### PR TITLE
Proxy icon fix

### DIFF
--- a/PBGitWindowController.m
+++ b/PBGitWindowController.m
@@ -42,6 +42,16 @@
 	return self;
 }
 
+- (void)synchronizeWindowTitleWithDocumentName
+{
+    [super synchronizeWindowTitleWithDocumentName];
+
+    // Point window proxy icon at project directory, not internal .git dir
+    NSString *workingDirectory = [self.repository workingDirectory];
+    [[self window] setRepresentedURL:[NSURL fileURLWithPath:workingDirectory
+                                                isDirectory:YES]];
+}
+
 - (void)windowWillClose:(NSNotification *)notification
 {
 	//DLog(@"Window will close!");


### PR DESCRIPTION
It's pretty rare you'd want to use the proxy icon to get to the .git
directory seeing as all document interactions such as open occur
at the higher level. (Bare repositories excepted.)

This should address laullon/gitx#106
