### PR TITLE
Fix crashes when opening Submodules.

### DIFF
--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -929,8 +929,19 @@ dispatch_queue_t PBGetWorkQueue() {
 	if(!workingDirectory) {
 		if ([self.fileURL.path hasSuffix:@"/.git"])
 			workingDirectory = [self.fileURL.path substringToIndex:[self.fileURL.path length] - 5];
-		else if ([[self outputForCommand:@"rev-parse --is-inside-work-tree"] isEqualToString:@"true"])
-			workingDirectory = [PBGitBinary path];
+        else {
+            NSRange range = [self.fileURL.path rangeOfString: @"/.git/modules/"];
+            if (range.location != NSNotFound) {
+                NSString *relativeModulePath = [self.fileURL.path substringFromIndex: range.location + range.length ];
+                NSString *supermodulePath = [self.fileURL.path substringToIndex: range.location];
+                workingDirectory = [supermodulePath stringByAppendingPathComponent: relativeModulePath];
+            }
+            else if ([[self outputForCommand:@"rev-parse --is-inside-work-tree"] isEqualToString:@"true"])
+                workingDirectory = [PBGitBinary path];
+            else
+                workingDirectory = self.fileURL.path;
+        }
+        
 	}
 	
 	return workingDirectory;

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -219,6 +219,9 @@ dispatch_queue_t PBGetWorkQueue() {
 	// We don't want the window controller to display anything yet..
 	// We'll leave that to the caller of this method.
 #ifndef CLI
+    if (![self workingDirectory]) { // If we couldn't find the working directory, assume it's the place we were opened from.
+        workingDirectory = [[path absoluteURL] path];
+    }
 	[self addWindowController:[[PBGitWindowController alloc] initWithRepository:self displayDefault:NO]];
 #endif
 


### PR DESCRIPTION
Subj, [theRepository workingDirectory] was nill & 

```
index = [[PBGitIndex alloc] initWithRepository:theRepository workingDirectory:[NSURL fileURLWithPath:[theRepository workingDirectory]]];
```

in the PBGitCommitController's -initWithRepository:superController:
