### PR TITLE
Use standard compare

### DIFF
--- a/Commands/PBCommand.m
+++ b/Commands/PBCommand.m
@@ -55,7 +55,7 @@
 									defaultButton:nil
 								  alternateButton:@"Cancel"
 									  otherButton:nil
-						informativeTextWithFormat:[NSString stringWithFormat:@"Are you sure you wish to perform this action?\n\n%@?",self.commandDescription]]
+						informativeTextWithFormat:@"Are you sure you wish to perform this action?\n\n%@?",self.commandDescription]
 					runModal];
 	}
 	

--- a/GLFileView.m
+++ b/GLFileView.m
@@ -111,17 +111,17 @@
             lastFile=file;
             
             NSString *fileTxt = @"";
-            if(startFile==@"fileview"){
+            if([@"fileview" isEqualToString:startFile]){
                 fileTxt=[file textContents:&theError];
                 if(!theError)
                     fileTxt=[GLFileView escapeHTML:fileTxt];
-            }else if(startFile==@"blame"){
+            }else if([@"blame" isEqualToString:startFile]){
                 fileTxt=[file blame:&theError];
                 if(!theError)
                     fileTxt=[self parseBlame:fileTxt];
-            }else if(startFile==@"log"){
+            }else if([@"log" isEqualToString:startFile]){
                 fileTxt=[file log:logFormat error:&theError];		
-            }else if(startFile==@"diff"){
+            }else if([@"diff" isEqualToString:startFile]){
                 fileTxt=[file diff:diffType error:&theError];
                 if(!theError)
                     fileTxt=[GLFileView parseDiff:fileTxt];
@@ -133,7 +133,7 @@
                 fileTxt=[fileTxt stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
                 DLog(@"file.sha='%@'",file.sha);
                 fileTxt=[fileTxt stringByReplacingOccurrencesOfString:@"{SHA_PREV}" withString:file.sha];
-                if(diffType==@"h") {
+                if([@"h" isEqualToString:diffType]) {
                     fileTxt=[fileTxt stringByReplacingOccurrencesOfString:@"{SHA}" withString:@"HEAD"];
                 }else {
                     fileTxt=[fileTxt stringByReplacingOccurrencesOfString:@"{SHA}" withString:@"--"];
@@ -219,7 +219,7 @@
 		startFile=identifier;
 	}else if(groupNumber==1){
 		diffType=identifier;
-		if(startFile==@"diff"){
+		if([@"diff" isEqualToString:startFile]){
 			[[view mainFrame] reload];
 		}
 	}
@@ -294,10 +294,10 @@
 		[res appendString:[NSString stringWithFormat:@"<a class='%@' href='#%@' representedFile='%@'>%@</a>",status,file,fileName,txt]];
 		[res appendString:@"</td><td class='bar'>"];
 		[res appendString:@"<div>"];
-		[res appendString:[NSString stringWithFormat:@"<span class='add' style='width:%d%%'></span>",((add*100)/granTotal)]];
-		[res appendString:[NSString stringWithFormat:@"<span class='rem' style='width:%d%%'></span>",((rem*100)/granTotal)]];
+		[res appendString:[NSString stringWithFormat:@"<span class='add' style='width:%ld%%'></span>",((add*100)/granTotal)]];
+		[res appendString:[NSString stringWithFormat:@"<span class='rem' style='width:%ld%%'></span>",((rem*100)/granTotal)]];
 		[res appendString:@"</div>"];
-		[res appendString:[NSString stringWithFormat:@"</td><td class='add'>+ %d</td><td class='rem'>- %d</td></tr>",add,rem]];
+		[res appendString:[NSString stringWithFormat:@"</td><td class='add'>+ %ld</td><td class='rem'>- %ld</td></tr>", (long)add, (long)rem]];
 	}
 	[res appendString:@"</table>"];
 	return res;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 		F56CC7320E65E0E5004307B4 /* PBGraphCellInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F56CC7310E65E0E5004307B4 /* PBGraphCellInfo.m */; };
 		F574A2850EAE2EAC003F2CB1 /* PBRefController.m in Sources */ = {isa = PBXBuildFile; fileRef = F574A2840EAE2EAC003F2CB1 /* PBRefController.m */; };
 		F574A2910EAE2FF4003F2CB1 /* PBGitConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FCCBA80EA8AF450061B02B /* PBGitConfig.m */; };
-		F57CC3910E05DDF2000472E2 /* PBEasyPipe.m in Sources */ = {isa = PBXBuildFile; fileRef = F57CC3900E05DDF2000472E2 /* PBEasyPipe.m */; };
+		F57CC3910E05DDF2000472E2 /* PBEasyPipe.m in Sources */ = {isa = PBXBuildFile; fileRef = F57CC3900E05DDF2000472E2 /* PBEasyPipe.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F57CC4410E05E496000472E2 /* PBGitWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F57CC4400E05E496000472E2 /* PBGitWindowController.m */; };
 		F580E6AE0E733276009E2D3F /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F580E6AD0E733276009E2D3F /* Sparkle.framework */; };
 		F580E6B10E73328C009E2D3F /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F580E6AD0E733276009E2D3F /* Sparkle.framework */; };

--- a/GitXRelativeDateFormatter.m
+++ b/GitXRelativeDateFormatter.m
@@ -36,7 +36,7 @@
 		return @"1 minute ago";
 
 	if (secondsAgo < HOUR)
-		return [NSString stringWithFormat:@"%d minutes ago", (secondsAgo / MINUTE)];
+		return [NSString stringWithFormat:@"%ld minutes ago", (secondsAgo / MINUTE)];
 
 	if (secondsAgo < (2 * HOUR))
 		return @"1 hour ago";
@@ -61,20 +61,20 @@
 			// return "hours ago" if it's still today, but "Yesterday" only if more than 6 hours ago
 			// gives people a little time to get used to the idea that yesterday is over :)
 			if ((daysAgo == 0) || (secondsAgo < (6 * HOUR)))
-				return [NSString stringWithFormat:@"%d hours ago", (secondsAgo / HOUR)];
+				return [NSString stringWithFormat:@"%ld hours ago", (secondsAgo / HOUR)];
 			if (daysAgo == 1)
 				return @"Yesterday";
 
 			if (daysAgo >= (2 * WEEK))
-				return [NSString stringWithFormat:@"%d weeks ago", (daysAgo / WEEK)];
+				return [NSString stringWithFormat:@"%ld weeks ago", (daysAgo / WEEK)];
 
-			return [NSString stringWithFormat:@"%d days ago", daysAgo];
+			return [NSString stringWithFormat:@"%ld days ago", daysAgo];
 		}
 
 		if (monthsAgo == 1)
 			return @"1 month ago";
 
-		return [NSString stringWithFormat:@"%d months ago", monthsAgo];
+		return [NSString stringWithFormat:@"%ld months ago", (long)monthsAgo];
 	}
 
 	if (yearsAgo == 1) {
@@ -84,10 +84,10 @@
 		if (monthsAgo == 1)
 			return @"1 year 1 month ago";
 
-		return [NSString stringWithFormat:@"1 year %d months ago", monthsAgo];
+		return [NSString stringWithFormat:@"1 year %ld months ago", (long)monthsAgo];
 	}
 
-	return [NSString stringWithFormat:@"%d years ago", yearsAgo];
+	return [NSString stringWithFormat:@"%ld years ago", (long)yearsAgo];
 }
 
 @end

--- a/NSString_RegEx.m
+++ b/NSString_RegEx.m
@@ -29,7 +29,8 @@
 		goto catch_error;	// regcomp error
 	
 	// Match the regular expression against substring self
-	pmatch = calloc(sizeof(regmatch_t), nmatch+1);
+	if (nmatch >= 0)
+		pmatch = calloc(sizeof(regmatch_t), nmatch+1);
 	errcode = regexec(&preg, [self UTF8String], (nmatch<0 ? 0 : nmatch+1), pmatch, 0);
 
 	/*if (errcode == REG_NOMATCH)

--- a/PBCloneRepositoryPanel.m
+++ b/PBCloneRepositoryPanel.m
@@ -84,7 +84,7 @@
 {
 	NSAlert *alert = [NSAlert alertWithMessageText:messageText
 									 defaultButton:nil alternateButton:nil otherButton:nil
-						 informativeTextWithFormat:infoText];
+						 informativeTextWithFormat:@"%@", infoText];
 	
 	[alert beginSheetModalForWindow:[self window]
 					  modalDelegate:self 

--- a/PBEasyPipe.m
+++ b/PBEasyPipe.m
@@ -17,7 +17,7 @@
 
 + (NSTask *) taskForCommand:(NSString *)cmd withArgs:(NSArray *)args inDir:(NSString *)dir
 {
-	NSMutableArray *filteredArguments = [[NSMutableArray alloc] init];
+	NSMutableArray *filteredArguments = [[[NSMutableArray alloc] init] autorelease];
 	for (NSString *param in args) {
 		if ([param length] > 0) {
 			[filteredArguments addObject:param];
@@ -39,7 +39,7 @@
 	NSPipe* pipe = [NSPipe pipe];
 	[task setStandardOutput:pipe];
 	[task setStandardError:pipe];
-	return task;
+	return [task autorelease];
 }
 
 + (NSFileHandle*) handleForCommand: (NSString*) cmd withArgs: (NSArray*) args inDir: (NSString*) dir
@@ -80,7 +80,7 @@
 	NSTask *task = [self taskForCommand:cmd withArgs:args inDir:dir];
 
 	if (dict) {
-		NSMutableDictionary *env = [[[NSProcessInfo processInfo] environment] mutableCopy];
+		NSMutableDictionary *env = [[[[NSProcessInfo processInfo] environment] mutableCopy] autorelease];
 		[env addEntriesFromDictionary:dict];
 		[task setEnvironment:env];
 	}
@@ -97,9 +97,9 @@
 	[task launch];
 	
 	NSData* data = [handle readDataToEndOfFile];
-	NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	NSString *string = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
 	if (!string)
-		string = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+		string = [[[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] autorelease];
 	
 	// Strip trailing newline
 	if ([string hasSuffix:@"\n"])

--- a/PBGitHistoryController.m
+++ b/PBGitHistoryController.m
@@ -181,7 +181,7 @@
 - (void) updateStatus
 {
 	self.isBusy = repository.revisionList.isUpdating;
-	self.status = [NSString stringWithFormat:@"%d commits loaded", [[commitController arrangedObjects] count]];
+	self.status = [NSString stringWithFormat:@"%lu commits loaded", (unsigned long)[[commitController arrangedObjects] count]];
 }
 
 - (void) restoreFileBrowserSelection

--- a/PBGitIndex.m
+++ b/PBGitIndex.m
@@ -490,7 +490,7 @@ NSString *PBGitIndexOperationFailed = @"PBGitIndexOperationFailed";
 
 - (NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
 {
-	NSString *parameter = [NSString stringWithFormat:@"-U%u", context];
+	NSString *parameter = [NSString stringWithFormat:@"-U%lu", (unsigned long)context];
 	if (staged) {
 		NSString *indexPath = [@":0:" stringByAppendingString:file.path];
 

--- a/PBGitIndexController.m
+++ b/PBGitIndexController.m
@@ -218,8 +218,8 @@
     NSString *messageText;
     NSString *informativeText;
     if ([files count] > 1) {
-        messageText = [NSString stringWithFormat:@"Delete %d files?",[files count]];
-        informativeText = [NSString stringWithFormat:@"Are you sure you want to move the selected %d files to the trash?\n\nYou cannot undo this operation.",[files count]];
+        messageText = [NSString stringWithFormat:@"Delete %lu files?", (unsigned long)[files count]];
+        informativeText = [NSString stringWithFormat:@"Are you sure you want to move the selected %lu files to the trash?\n\nYou cannot undo this operation.", (unsigned long)[files count]];
     }
     else {
         messageText = @"Delete file?";
@@ -235,7 +235,7 @@
 									 defaultButton:@"Delete"
 								   alternateButton:@"Cancel"
 									   otherButton:nil
-						 informativeTextWithFormat:informativeText];
+						 informativeTextWithFormat:@"%@", informativeText];
     [alert setShowsSuppressionButton:YES];
 	
 	[alert beginSheetModalForWindow:[[commitController view] window]

--- a/PBGitRepository.m
+++ b/PBGitRepository.m
@@ -1507,7 +1507,7 @@ dispatch_queue_t PBGetWorkQueue() {
                                     defaultButton:@"Yes"
                                   alternateButton:@"No"
                                       otherButton:nil
-                        informativeTextWithFormat:[NSString stringWithFormat:@"Delete branch %@ on remote %@?",[ref remoteBranchName],[ref remoteName]]]
+                        informativeTextWithFormat:@"Delete branch %@ on remote %@?",[ref remoteBranchName],[ref remoteName]]
                     runModal];
     
     if (alertRet == NSAlertDefaultReturn)
@@ -1556,7 +1556,7 @@ dispatch_queue_t PBGetWorkQueue() {
                                                 defaultButton:@"Yes"
                                               alternateButton:@"No"
                                                   otherButton:nil
-                                    informativeTextWithFormat:[NSString stringWithFormat:@"Delete tag %@ on remote %@?",[ref tagName],[remotes objectAtIndex:i]]]
+                                    informativeTextWithFormat:@"Delete tag %@ on remote %@?",[ref tagName],[remotes objectAtIndex:i]]
                                 runModal];
                 
                 if (alertRet == NSAlertDefaultReturn)
@@ -1577,8 +1577,8 @@ dispatch_queue_t PBGetWorkQueue() {
                                          defaultButton:@"OK" 
                                        alternateButton:nil 
                                            otherButton:nil
-                             informativeTextWithFormat:[NSString stringWithFormat:@"%@\n\n%@",argumentsString,output]
-                          ] runModal];
+                             informativeTextWithFormat:@"%@\n\n%@",argumentsString,output]
+                         runModal];
                     }
                     
                     [self reloadRefs];

--- a/PBGitSidebarController.m
+++ b/PBGitSidebarController.m
@@ -418,7 +418,7 @@ NSString *kObservingContextSubmodules = @"submodulesChanged";
 	if ([fetchURL isEqual:pushURL])
 		return fetchURL;
 	else	// Down triangle for fetch, up triangle for push
-		return [NSString stringWithFormat:@"\u25bc %@\n\u25b2", fetchURL, pushURL];
+		return [NSString stringWithFormat:@"\u25bc %@\n\u25b2 %@", fetchURL, pushURL];
 }
 
 - (void)populateList

--- a/PBGitTree.m
+++ b/PBGitTree.m
@@ -162,10 +162,10 @@
 		error=[NSString stringWithFormat:@"This is a tree with path %@", [self fullPath]];
 	
 	if ([self hasBinaryAttributes])
-		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %d bytes", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %lld bytes", [self fullPath], [self fileSize]];
 	
 	if ([self fileSize] > 52428800) // ~50MB
-		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%d bytes)", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%lld bytes)", [self fullPath], [self fileSize]];
 	
 	if(error==nil){
 		res=[repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"blame", @"-p",  sha, @"--", [self fullPath], nil]];
@@ -204,23 +204,23 @@
 		error=[NSString stringWithFormat:@"This is a tree with path %@", [self fullPath]];
 	
 	if ([self hasBinaryAttributes])
-		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %d bytes", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %lld bytes", [self fullPath], [self fileSize]];
 	
 	if ([self fileSize] > 52428800) // ~50MB
-		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%d bytes)", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%lld bytes)", [self fullPath], [self fileSize]];
 	
 	if(error==nil){
 		NSString *des=@"";
-		if(format==@"p") {
+		if([@"p" isEqualToString:format]) {
 			des=[NSString stringWithFormat:@"%@^",sha];
-		}else if(format==@"h") {
+		}else if([@"h" isEqualToString:format]) {
 			des=@"HEAD";
 		}else{
 			des=@"--";
 		}
 		res=[repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"diff", sha, des,[self fullPath], nil]];
 		if ([res length]==0) {
-			DLog(@"--%@",[res length]);
+			DLog(@"--%lu",(unsigned long)[res length]);
 			if (anError != NULL) {
 				*anError = [NSError errorWithDomain:@"diff" code:1 userInfo:[NSDictionary dictionaryWithObjectsAndKeys:@"No Diff",NSLocalizedDescriptionKey,nil]];
 			}
@@ -244,10 +244,10 @@
 		error=[NSString stringWithFormat:@"This is a tree with path %@", [self fullPath]];
 	
 	if ([self hasBinaryAttributes])
-		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %d bytes", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ appears to be a binary file of %lld bytes", [self fullPath], [self fileSize]];
 	
 	if ([self fileSize] > 52428800) // ~50MB
-		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%d bytes)", [self fullPath], [self fileSize]];
+		error=[NSString stringWithFormat:@"%@ is too big to be displayed (%lld bytes)", [self fullPath], [self fileSize]];
 	
 	if(error==nil){
 		res = [self contents];

--- a/PBHistorySearchController.m
+++ b/PBHistorySearchController.m
@@ -195,7 +195,7 @@
 	if (numberOfMatches == 1)
 		return @"1 match";
 
-	return [NSString stringWithFormat:@"%d matches", numberOfMatches];
+	return [NSString stringWithFormat:@"%lu matches", (unsigned long)numberOfMatches];
 }
 
 - (void)updateUI

--- a/PBRefController.m
+++ b/PBRefController.m
@@ -475,13 +475,12 @@
 	NSString *subject = [dropCommit subject];
 	if ([subject length] > 99)
 		subject = [[subject substringToIndex:99] stringByAppendingString:@"…"];
-	NSString *infoText = [NSString stringWithFormat:@"Move the %@ to point to the commit: %@", [ref refishType], subject];
 
 	NSAlert *alert = [NSAlert alertWithMessageText:[NSString stringWithFormat:@"Move %@: %@", [ref refishType], [ref shortName]]
 									 defaultButton:@"Move"
 								   alternateButton:@"Cancel"
 									   otherButton:nil
-						 informativeTextWithFormat:infoText];
+						 informativeTextWithFormat:@"Move the %@ to point to the commit: %@", [ref refishType], subject];
     [alert setShowsSuppressionButton:YES];
 
 	[alert beginSheetModalForWindow:[historyController.repository.windowController window]

--- a/PBRemoteProgressSheet.m
+++ b/PBRemoteProgressSheet.m
@@ -395,9 +395,9 @@ static PBGitRepository *repository;
 	NSString *standardError = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
 	if ([standardError isEqualToString:@""])
-		return [NSString stringWithFormat:@"\nerror = %d", returnCode];
+		return [NSString stringWithFormat:@"\nerror = %ld", (long)returnCode];
 
-	return [NSString stringWithFormat:@"\n\n%@\nerror = %d", standardError, returnCode];
+	return [NSString stringWithFormat:@"\n\n%@\nerror = %ld", standardError, (long)returnCode];
 }
 
 

--- a/PBSourceViewBadge.m
+++ b/PBSourceViewBadge.m
@@ -42,11 +42,13 @@
 	if (![cell isHighlighted])
 		return [NSColor whiteColor];
 
-	if (![[[cell controlView] window] isKeyWindow])
-		if ([[[cell controlView] window] isMainWindow])
+	if (![[[cell controlView] window] isKeyWindow]) {
+		if ([[[cell controlView] window] isMainWindow]) {
 			return [self badgeHighlightColor];
-		else 
+		} else {
 			return [self badgeBackgroundColor];
+		}
+	}
 
 	if ([[[cell controlView] window] firstResponder] == [cell controlView])
 		return [self badgeHighlightColor];
@@ -115,7 +117,7 @@
 
 + (NSImage *) numericBadge:(NSInteger)number forCell:(NSTextFieldCell *)cell
 {
-	return [self badge:[NSString stringWithFormat:@"%d", number] forCell:cell];
+	return [self badge:[NSString stringWithFormat:@"%ld", (long)number] forCell:cell];
 }
 
 @end

--- a/PBSourceViewItem.m
+++ b/PBSourceViewItem.m
@@ -59,7 +59,7 @@
 
 	[self.children addObject:child];
 	child.parent = self;
-	[self.children sortUsingDescriptors:[NSArray arrayWithObject:[[NSSortDescriptor alloc] initWithKey:@"title" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]]];
+	[self.children sortUsingDescriptors:[NSArray arrayWithObject:[[NSSortDescriptor alloc] initWithKey:@"title" ascending:YES selector:@selector(localizedStandardCompare:)]]];
 }
 
 - (void)addChildWithoutSort:(PBSourceViewItem *)child

--- a/PBWebCommitController.m
+++ b/PBWebCommitController.m
@@ -132,7 +132,7 @@ const NSString *kAuthorKeyDate = @"date";
             NSString *diffs = [GLFileView parseDiff:d];
             html = [NSString stringWithFormat:@"%@%@%@",header,fileList,diffs];
         } else {
-            html = [NSString stringWithFormat:@"%@%@<div id='diffs'><p>This is a very large commit. It may take a long time to load the diff. Click <a href='' onclick='showFullDiff(); return false;'>here</a> to show anyway.</p></div>",header,fileList,currentSha];
+            html = [NSString stringWithFormat:@"%@%@<div id='diffs'><p>This is a very large commit. It may take a long time to load the diff. Click <a href='' onclick='showFullDiff(); return false;'>here</a> to show anyway.</p></div>",header,fileList];
         }
 
         html = [html stringByReplacingOccurrencesOfString:@"{SHA_PREV}" withString:[NSString stringWithFormat:@"%@^",currentSha]];

--- a/PBWebController.m
+++ b/PBWebController.m
@@ -182,7 +182,10 @@
 {
 	SEL selector = NSSelectorFromString([arguments objectAtIndex:0]);
 	id object = [arguments objectAtIndex:1];
+#pragma clang diagnostics push
+#pragma clang diagnostics ignore "-Wselector"
 	id ret = [object performSelector:selector];
+#pragma clang diagnostics pop
 	NSArray *returnArray = [NSArray arrayWithObjects:[NSThread currentThread], ret, nil];
 	[self performSelectorOnMainThread:@selector(threadFinished:) withObject:returnArray waitUntilDone:NO];
 }

--- a/gitx.m
+++ b/gitx.m
@@ -115,7 +115,7 @@ void handleSTDINDiff()
 {
 	NSFileHandle *handle = [NSFileHandle fileHandleWithStandardInput];
 	NSData *data = [handle readDataToEndOfFile];
-	NSString *diff = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	NSString *diff = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
 
 	if (diff && [diff length] > 0) {
 		GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
@@ -324,7 +324,7 @@ NSURL *workingDirectoryURL(NSMutableArray *arguments)
 
 NSMutableArray *argumentsArray()
 {
-	NSMutableArray *arguments = [[[NSProcessInfo processInfo] arguments] mutableCopy];
+	NSMutableArray *arguments = [[[[NSProcessInfo processInfo] arguments] mutableCopy] autorelease];
 	[arguments removeObjectAtIndex:0]; // url to executable path is not needed
 
 	return arguments;

--- a/gitx_askpasswd_main.m
+++ b/gitx_askpasswd_main.m
@@ -55,7 +55,7 @@ OSStatus			StorePasswordKeychain (const char *url, UInt32 urlLength, void* passw
 @implementation GAPAppDelegate 
 
 -(void)yesNo:(NSString *)prompt url:(NSString *)url{
-    NSAlert *alert = [[NSAlert alloc] init];
+    NSAlert *alert = [[[NSAlert alloc] init] autorelease];
     [alert addButtonWithTitle:@"YES"];
     [alert addButtonWithTitle:@"NO"];
     [alert setMessageText:[NSString stringWithFormat:@"%@?",url]];
@@ -77,7 +77,7 @@ OSStatus			StorePasswordKeychain (const char *url, UInt32 urlLength, void* passw
     
     NSRect box = NSMakeRect(0, 0, 200, 24);
     
-    NSSecureTextField * passView = [[NSSecureTextField alloc] initWithFrame: box];
+    NSSecureTextField * passView = [[[NSSecureTextField alloc] initWithFrame: box] autorelease];
     [passView setSelectable: YES];
     [passView setEditable: YES];
     [passView setBordered: YES];
@@ -86,7 +86,7 @@ OSStatus			StorePasswordKeychain (const char *url, UInt32 urlLength, void* passw
     [passView selectText: self];
     
     
-    NSAlert *alert = [[NSAlert alloc] init];
+    NSAlert *alert = [[[NSAlert alloc] init] autorelease];
     [alert addButtonWithTitle:@"Ok"];
     [alert addButtonWithTitle:@"cancel"];
     [alert setMessageText:[NSString stringWithFormat:@"%@?",url]];
@@ -141,6 +141,7 @@ void getproclline(pid_t pid, char *command_name)
 	
 	size = (size_t)argmax;
 	if (sysctl(mib, 3, procargs, &size, NULL, 0) == -1) {
+		free(procargs);
 		return;
 	}
 	
@@ -155,6 +156,7 @@ void getproclline(pid_t pid, char *command_name)
 		}
 	}
 	if (cp == &procargs[size]) {
+		free(procargs);
 		return;
 	}
 	
@@ -166,6 +168,7 @@ void getproclline(pid_t pid, char *command_name)
 		}
 	}
 	if (cp == &procargs[size]) {
+		free(procargs);
 		return;
 	}
 	/* Save where the argv[0] string starts. */
@@ -226,7 +229,7 @@ int	main( int argc, const char* argv[] )
 	TransformProcessType( &myPSN, kProcessTransformToForegroundApplication );
 	
 	NSApplication *app = [NSApplication sharedApplication];
-	GAPAppDelegate *appDel = [[GAPAppDelegate alloc] init];
+	GAPAppDelegate *appDel = [[[GAPAppDelegate alloc] init] autorelease];
 	[app setDelegate:appDel];
     
 	


### PR DESCRIPTION
Standard compare is “natural sorting” and will sort 10 after 9, instead of after 1 and before 2.

That way, tag version numbers like 1.1.10 will be shown after 1.1.9 and not after 1.1.1 and before 1.1.2.
