### PR TITLE
Fixed a bug in GitX (L) that for some cases the "file link" in the changes-of-a-commit view cannot jump

### DIFF
--- a/GLFileView.m
+++ b/GLFileView.m
@@ -465,7 +465,7 @@
 
 +(NSString *)getFileName:(NSString *)line
 {
-    NSRange b = [line rangeOfString:@"b/"];
+    NSRange b = [line rangeOfString:@" b/"];
 	if (b.length == 0)
 		b = [line rangeOfString:@"--cc "];
 	


### PR DESCRIPTION
Any "file link" in the changes-of-a-commit view cannot jump, when the file's path contain substring "b/", e.g. file path cab/xxx.txt.  However, if the path have a folder with name ended in " b" (very rare), it will not work, still.
